### PR TITLE
Add assign wcs

### DIFF
--- a/caltest/conftest.py
+++ b/caltest/conftest.py
@@ -37,8 +37,8 @@ def pytest_generate_tests(metafunc):
     with open(metafunc.config.option.config) as config_file:
         config = json.load(config_file)
     steps = ['dq_init', 'saturation', 'superbias', 'persistence',
-             'linearity', 'dark_current',
-             'jump', 'ramp_fit']
+             'linearity', 'dark_current', 'jump', 'ramp_fit',
+             'assign_wcs']
     # parametrize tests with the input files supplied for that step
     for step in steps:
         if step in metafunc.module.__name__ and config.get(step):

--- a/caltest/conftest.py
+++ b/caltest/conftest.py
@@ -36,13 +36,16 @@ def pytest_runtest_setup(item):
 def pytest_generate_tests(metafunc):
     with open(metafunc.config.option.config) as config_file:
         config = json.load(config_file)
-    steps = ['dq_init', 'saturation', 'superbias', 'linearity', 'dark_current',
+    steps = ['dq_init', 'saturation', 'superbias', 'persistence',
+             'linearity', 'dark_current',
              'jump', 'ramp_fit']
     # parametrize tests with the input files supplied for that step
     for step in steps:
         if step in metafunc.module.__name__ and config.get(step):
-            metafunc.parametrize("input_file", config[step], scope='module')
-
+            if step != "persistence":
+                metafunc.parametrize("input_file", config[step], scope='module')
+            else:
+                metafunc.parametrize(["input_file","trapsfilled"], config[step], scope='module')
 
 @pytest.fixture(scope='module')
 def fits_input(input_file):

--- a/caltest/test_caldetector1/test_assign_wcs.py
+++ b/caltest/test_caldetector1/test_assign_wcs.py
@@ -1,0 +1,310 @@
+import pytest
+import sys, os
+import numpy as np
+from jwst.assign_wcs import AssignWcsStep
+from jwst import datamodels
+from asdf import AsdfFile
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+
+
+@pytest.fixture(scope='module')
+def in_datamodel(fits_input):
+    '''open input file as a datamodel'''
+    yield datamodels.open(fits_input[0].header['FILENAME'])
+    
+    
+@pytest.fixture(scope='module')
+def out_datamodel(in_datamodel):
+    '''open output file'''
+    outname = '_assign_wcs.'.join(in_datamodel.meta.filename.split('.'))
+    yield datamodels.open(outname)
+    os.remove(outname)
+
+    
+@pytest.fixture(scope='module')
+def dist_reffile(out_datamodel):
+    '''determine the distortion reference file used'''
+    origname = out_datamodel.meta.ref_file.distortion.name
+    if 'crds://' in origname:
+        origname = origname.replace('crds://','/grp/crds/cache/references/jwst/')
+    yield origname
+    
+    
+def test_assign_wcs_step(in_datamodel):
+    '''Run the assign_wcs pipeline step'''
+    outfile = in_datamodel.meta.filename.replace('.fits','_assign_wcs.fits')
+    AssignWcsStep.call(in_datamodel,output_file = outfile,save_results=True)
+
+
+def test_asdf_extension(fits_input):
+    '''Make sure there is a new ASDF extension in the output file'''
+    print("Test to be sure the ASDF extension was added to the file")
+    outname = '_assign_wcs.'.join(fits_input[0].header['FILENAME'].split('.'))
+    h = fits.open(outname)
+    exts = []
+    for i in range(1,len(h)):
+        exts.append(h[i].header['EXTNAME'])
+    assert 'ASDF' in exts
+    
+        
+def test_inserted_wcs_model(out_datamodel):
+    '''Check RA, Dec values from output file WCS model 
+    are correct for refrence location. Check pixel scale implied
+    by the WCS model'''
+
+    expectedra = out_datamodel.meta.wcsinfo.ra_ref
+    expecteddec = out_datamodel.meta.wcsinfo.dec_ref
+
+    refloc_x = out_datamodel.meta.wcsinfo.crpix1 - 1
+    refloc_y = out_datamodel.meta.wcsinfo.crpix2 - 1
+
+    # pixel scale in arcsec per pixel
+    xpixscale = out_datamodel.meta.wcsinfo.cdelt1 * 3600.
+    ypixscale = out_datamodel.meta.wcsinfo.cdelt2 * 3600.
+    #distscale = np.sqrt(xpixscale**2 + ypixscale**2)
+    
+    # Tolerance to use when checking if values are close enough
+    atol_pix = 0.01
+    xatol_arcsec = atol_pix * xpixscale
+    yatol_arcsec = atol_pix * ypixscale
+    
+    #check pixel scale by reporting RA,Dec of adjacent pixels
+    exp_type = out_datamodel.meta.exposure.type
+    if 'GRISM' not in exp_type: # imaging data
+        refra,refdec = out_datamodel.meta.wcs(refloc_x,refloc_y)
+        adra,addec   = out_datamodel.meta.wcs(refloc_x+1,refloc_y)
+        ad2ra,ad2dec = out_datamodel.meta.wcs(refloc_x,refloc_y+1)
+
+        pos1 = SkyCoord(ra=adra, dec=addec, unit='deg')
+        refpos_skycoords = SkyCoord(ra=refra, dec=refdec, unit='deg')
+        dist = refpos_skycoords.separation(pos1).value * 3600
+
+        pos2 = SkyCoord(ra=ad2ra, dec=ad2dec, unit='deg')
+        dist2 = refpos_skycoords.separation(pos2).value * 3600
+
+        print('Expected RA, Dec at reference location (deg):',expectedra,expecteddec)
+        print('Ref loc. RA, Dec (deg):',refra,refdec)
+        print('RA, Dec of adjacent pixel (deg):',adra,addec)
+        print('Delta Distance, horiz. adjacent pix: (arcsec)',dist)
+        print('Delta Distance, vertical adjacent pix: (arcsec)',dist2)
+        
+        assert np.allclose(expectedra,refra,atol=xatol_arcsec,rtol=0.)
+        assert np.allclose(expecteddec,refdec,atol=yatol_arcsec,rtol=0)
+        assert np.allclose(dist,xpixscale,atol=yatol_arcsec,rtol=0)
+        assert np.allclose(dist2,ypixscale,atol=yatol_arcsec,rtol=0)
+
+
+    else: # WFSS data
+        pupil = out_datamodel.meta.instrument.pupil
+        filter = out_datamodel.meta.instrument.filter #to support NIRISS grism
+        if pupil[0] == 'G':
+            pass
+        elif filter[0] == 'G':
+            pupil = filter
+        grisms_r = ['GRISMR','G150R']
+        grisms_c = ['GRISMC','G150C']
+        adjpix = (None,None)
+        adjwave = (None,None)
+        if pupil in grisms_r:
+            adjpix = (0,1) # delta x, delta y
+            adjwave = (1,0)
+        elif pupil in grism_c:
+            adjpix = (1,0)
+            adjwave = (0,1)
+        else:
+            print("Grism value of {} is not recognized. Skipping testing.".format(pupil))
+
+        if adjwave[0] is not None:
+            # RA, Dec, Wavelength, Order for the reference location
+            # pixel in the dispersed image
+            refra,refdec,refwave,reforder = out_datamodel.meta.wcs(refloc_x
+                                                                   ,refloc_y
+                                                                   ,refloc_x
+                                                                   ,refloc_y,1)
+
+            # Move one pixel in the dispersion direction in the dispersed
+            # image (refloc in direct image). Should have same RA, Dec as
+            # reference location in direct image.
+            adwavera,adwavedec,adwavewave,adwaveord = out_datamodel.meta.wcs(refloc_x+adjwave[0]
+                                                                             ,refloc_y+adjwave[1]
+                                                                             ,refloc_x,refloc_y,1)
+
+            # Move one pixel perp to dispersion direction in dispersed
+            # image (refloc in direct image). Should have same RA, Dec as
+            # reference location in direct image. Should also have same
+            # wavelength as reference location.
+            adpixra,adpixdec,adpixwave,adpixord = out_datamodel.meta.wcs(refloc_x+adjpix[0],
+                                                                         refloc_y+adjpix[1],
+                                                                         refloc_x,refloc_y,1)
+        
+            # Move one pixel in the dispersion direction in both the dispersed
+            # AND direct image. The resulting wavelength should be the same as
+            # refwave case above.
+            dra,ddec,dwave,dord = out_datamodel.meta.wcs(refloc_x+adjwave[0],refloc_y+adjwave[1],
+                                                         refloc_x+adjwave[0],refloc_y+adjwave[1],1)
+
+            # Calculate distances to compare with the stated pixel scale
+            pos1 = SkyCoord(ra=dra, dec=ddec, unit='deg')
+            refpos_skycoords = SkyCoord(ra=refra, dec=refdec, unit='deg')
+            ddist = refpos_skycoords.separation(pos1).value * 3600
+
+            print('Expected RA, Dec at reference location (deg):',expectedra,expecteddec)
+            print('Ref loc. RA, Dec (deg):',refra,refdec)
+            print('RA, Dec of adjacent pixel (deg):',dra,ddec)
+            print('Delta Distance, horiz. adjacent pix: (arcsec)',ddist)
+
+            assert np.allclose(expectedra,refra,atol=xatol_arcsec,rtol=0.)
+            assert np.allclose(expecteddec,refdec,atol=yatol_arcsec,rtol=0)
+            assert np.allclose(refra,adwavera,atol=1e-8,rtol=0.)
+            assert np.allclose(refdec,adwavedec,atol=1e-8,rtol=0.)
+            assert np.allclose(refra,adpixra,atol=1e-8,rtol=0.)
+            assert np.allclose(refdec,adpixdec,atol=1e-8,rtol=0.)
+            assert np.allclose(refwave,adpixwave,atol=1e-10,rtol=0.)
+            assert np.allclose(refwave,dwave,atol=1e-10,rtol=0.)
+            assert np.allclose(ddist,xpixscale,atol=0.0005,rtol=0.)
+        
+        
+def test_wcs_vs_reffile(out_datamodel,dist_reffile):
+    '''Test WCS model in the distortion reference file
+    matches that in the output file'''
+
+    print("Distortion reference file used: {}".format(dist_reffile))
+    distortion = AsdfFile.open(dist_reffile).tree['model']
+    reverse = distortion.inverse
+
+    refx = out_datamodel.meta.wcsinfo.crpix1 - 1
+    refy = out_datamodel.meta.wcsinfo.crpix2 - 1
+
+    shape = out_datamodel.data.shape
+    if len(shape) == 2:
+        ylen,xlen = shape
+    elif len(shape) == 3:
+        nint,ylen,xlen = shape
+
+    inx = [refx]
+    iny = [refy]
+    fractions = [0.1,0.3,0.5,0.7,0.9]
+    for f in fractions:
+        xup = int(xlen * f)
+        yup = int(ylen * f)
+        ydown = ylen - yup
+        inx.append(xup)
+        iny.append(yup)
+        inx.append(xup)
+        iny.append(ydown)
+
+    # Convert x,y positions to RA, Dec and back, to see if
+    # you recover the same x,y
+    reffilex = np.array([])
+    reffiley = np.array([])
+    modx = np.array([])
+    mody = np.array([])
+    exp_type = out_datamodel.meta.exposure.type
+    if 'GRISM' not in exp_type: # imaging data
+        for x,y in zip(inx,iny):
+            refra,refdec = distortion(x,y)
+            refnewx,refnewy = reverse(refra,refdec)
+            reffilex = np.append(reffilex,refnewx)
+            reffiley = np.append(reffiley,refnewy)
+            fra, fdec = out_datamodel.meta.wcs(x,y)
+            fnewx, fnewy = out_datamodel.meta.wcs.backward_transform(fra,fdec)
+            modx = np.append(modx,fnewx)
+            mody = np.append(mody,fnewy)
+
+        print("Input x coords:")
+        print(inx)
+        print("X coords from reference file WCS model:")
+        print(reffilex)
+        print("X coords from output file WCS model:")
+        print(modx)
+
+        print("Input y coords:")
+        print(iny)
+        print("Y coords from reference file WCS model:")
+        print(reffiley)
+        print("Y coords from output file WCS model:")
+        print(mody)
+        assert np.allclose(reffilex,modx,atol=1e-8,rtol=0.)
+        assert np.allclose(reffiley,mody,atol=1e-8,rtol=0.)
+
+    else:
+        print("This test not implemented for GRISM data.")
+        
+        # The GRISM comparison below would need more work before
+        # it could be used. The creation of the WCS model to go into
+        # the output file is more complicated than in the imaging case
+        # and it's not clear how to create this WCS without simply
+        # copying the code in the JWST pipeline
+    #else:  # GRISM data
+    #    refdirectx = np.array([])
+    #    refdirecty = np.array([])
+    #    reffilewave = np.array([])
+    #    reforder = np.array([])
+    #    moddirectx = np.array([])
+    #    moddirecty = np.array([])
+    #    modwave = np.array([])
+    #    modorder = np.array([])
+    #
+    #    pupil = out_datamodel.meta.instrument.pupil
+    #    filter = out_datamodel.meta.instrument.filter #to support NIRISS grism
+    #    if pupil[0] == 'G':
+    #        pass
+    #    elif filter[0] == 'G':
+    #        pupil = filter
+    #    grisms_r = ['GRISMR','G150R']
+    #    grisms_c = ['GRISMC','G150C']
+    #            
+    #    for x,y in zip(inx,iny):
+    #        #refra,refdec,refwave,reford = distortion(x,y,refx,refy,1)
+    #        #refnewx,refnewy,refdirx,refdiry,refneworder = reverse(refra,refdec,refwave,reford)
+    #        #reffilex = np.append(reffilex,refnewx)
+    #        #reffiley = np.append(reffiley,refnewy)
+    #        #refdirectx = np.append(refdirectx,refdirx)
+    #        #refdirecty = np.append(refdirecty,refdiry)
+    #        #reffilewave = np.append(reffilewave,refwave)
+    #        #reforder = np.append(reforder,refneworder)
+    #        refra,refdec = distortion(x,y)
+    #        refnewx,refnewy = reverse(refra,refdec)
+    #        if pupil in grisms_r:
+    #            reffilex = np.append(reffilex,refnewx)
+    #            reffiley = np.append(reffiley,refy)
+    #        elif pupil in grisms_c:
+    #            reffilex = np.append(reffilex,refx)
+    #            reffiley = np.append(reffiley,refnewy)
+    #
+    #        fra, fdec, fwave, forder = out_datamodel.meta.wcs(x,y,refx,refy,1)
+    #        fdispx, fdispy, fdirectx, fdirecty, ford = out_datamodel.meta.wcs.backward_transform(fra,fdec,fwave,forder)
+    #
+    #        print(x,fdispx,y,fdispy)
+    #
+    #        
+    #        if pupil in grisms_r:
+    #            modx = np.append(modx,fdispx)
+    #            mody = np.append(mody,refy)
+    #            moddirectx = np.append(moddirectx,fdirectx)
+    #            moddirecty = np.append(moddirecty,fdirecty)
+    #            modwave = np.append(modwave,fwave)
+    #            modorder = np.append(modorder,ford)
+    #        elif pupil in grisms_c:
+    #            modx = np.append(modx,refx)
+    #            mody = np.append(mody,fdispy)
+    #            moddirectx = np.append(moddirectx,fdirectx)
+    #            moddirecty = np.append(moddirecty,fdirecty)
+    #            modwave = np.append(modwave,fwave)
+    #            modorder = np.append(modorder,ford)
+    #            
+    #            
+    #    print('reffilex, modx, reffiley, mody')
+    #    print(reffilex)
+    #    print(modx)
+    #    print(reffiley)
+    #    print(mody)
+    #        
+    #    assert np.allclose(reffilex,modx,atol=1e-8,rtol=0.)
+    #    assert np.allclose(reffiley,mody,atol=1e-8,rtol=0.)
+    #    #assert np.allclose(refdirectx,moddirectx,atol=1e-8,rtol=0.)
+    #    #assert np.allclose(refdirecty,moddirecty,atol=1e-8,rtol=0.)
+    #    #assert np.allclose(reffilewave,modwave,atol=1e-8,rtol=0.)
+    #    #assert np.allclose(reforder,modorder,atol=1e-8,rtol=0.)
+

--- a/caltest/test_caldetector1/test_persistence.py
+++ b/caltest/test_caldetector1/test_persistence.py
@@ -1,0 +1,212 @@
+#! /usr/bin/env python
+
+'''
+Test the persistence step of the pipeline. Written during 
+testing of build 7.1
+
+Validation Part 1:
+Check that trapsfilled file is generated correctly
+Check that it’s (the step?) used correctly
+
+
+SSB documentation:
+Based on a model, this step computes the number of traps 
+that are expected to have captured or released a charge 
+during an exposure. The released charge is proportional 
+to the persistence signal, and this will be subtracted 
+(group by group) from the science data. An image of the 
+number of filled traps at the end of the exposure will 
+be written as an output file, in order to be used as input 
+for correcting the persistence of a subsequent exposure.
+
+Input
+The input science file is a RampModel.
+
+A trapsfilled file (TrapsFilledModel) may optionally be 
+passed as input as well. This normally would be specified 
+unless the previous exposure with the current detector was 
+taken more than several hours previously, that is, so long 
+ago that persistence from that exposure could be ignored.
+
+Output
+The output science file is a RampModel, a persistence-corrected 
+copy of the input data.
+
+A second output file will be written, with suffix “_trapsfilled”. 
+This is a TrapsFilledModel, the number of filled traps at each 
+pixel at the end of the exposure. This takes into account the 
+capture of charge by traps due to the current science exposure, 
+as well as the release of charge from traps shown in the input 
+trapsfilled file, if one was specified.
+
+If the user specified save_persistence=True, a third output file 
+will be written, with suffix “_output_pers”. This is a RampModel 
+matching the output science file, but this gives the persistence 
+that was subtracted from each group in each integration.
+
+input file -> run persistence step -> output hdu and file -> 
+run tests against...what truth?
+
+'''
+
+import pytest
+import os
+import numpy as np
+from astropy.io import fits
+from jwst import datamodels
+from jwst.persistence import PersistenceStep
+#from jwst.datamodels import TrapsFilledModel
+from jwst.datamodels import dqflags
+
+
+#@pytest.fixture(scope="module")
+#def input_hdul(request, config):
+#    if  config.has_option("persistence", "input_file"):
+#        curdir = os.getcwd()
+#        config_dir = os.path.dirname(request.config.getoption("--config_file"))
+#        os.chdir(config_dir)
+#        hdul = fits.open(config.get("persistence", "input_file"))
+#        os.chdir(curdir)
+#        return hdul
+#    else:
+#       pytest.skip("needs persistence input_file")
+
+        
+@pytest.fixture(scope="module")
+def out_hdul(fits_input):
+    fname = '_persist.'.join(fits_input[0].header['filename'].split('.'))
+    yield fits.open(fname)
+    #os.remove(fname)
+
+
+@pytest.fixture(scope="module")
+def trapsfilled_hdul(trapsfilled):
+    yield fits.open(trapsfilled)
+
+
+@pytest.fixture(scope='module')
+def traps_hdul(fits_input):
+    fname = '_trapsfilled.'.join(fits_input[0].header['filename'].split('.'))
+    yield fits.open(fname)
+    #os.remove(fname)
+
+
+@pytest.fixture(scope='module')
+def pers_hdul(fits_input):
+    fname = '_output_pers.'.join(fits_input[0].header['filename'].split('.'))
+    try:
+        hdul = fits.open(fname)
+    except:
+        print("output_pers file not present")
+        hdul = None    
+    yield hdul
+    #os.remove(fname)
+
+    
+@pytest.fixture(scope="module")
+def persat_hdul(out_hdul):
+    CRDS = '/grp/crds/cache/references/jwst/'
+    ref_file = output_hdul[0].header['R_PERSAT']
+    if 'crds://' in ref_file:
+        ref_file = ref_file.replace('crds://',CRDS)
+    return fits.open(ref_file)
+
+
+@pytest.fixture(scope="module")
+def trpden_hdul(output_hdul):
+    CRDS = '/grp/crds/cache/references/jwst/'
+    ref_file = output_hdul[0].header['R_TRPDEN']
+    if 'crds://' in ref_file:
+        ref_file = ref_file.replace('crds://',CRDS)
+    return fits.open(ref_file)
+
+
+@pytest.fixture(scope="module")
+def trppar_hdul(output_hdul):
+    CRDS = '/grp/crds/cache/references/jwst/'
+    ref_file = output_hdul[0].header['R_TRPPAR']
+    if 'crds://' in ref_file:
+        ref_file = ref_file.replace('crds://',CRDS)
+    return fits.open(ref_file)
+
+
+def test_run_persist_step(fits_input,trapsfilled):
+    outfile = fits_input[0].header['FILENAME'].replace('.fits','_persist.fits')
+    if trapsfilled.lower() in ["none",""]:
+        PersistenceStep.call(fits_input,save_persistence=True,\
+                             output_file=outfile,save_results=True)
+    else:
+        PersistenceStep.call(fits_input,save_persistence=True,\
+                             output_file=outfile,save_results=True,\
+                             input_trapsfilled=trapsfilled)
+
+
+def test_persistence_trapsfilled_shape(fits_input,traps_hdul,trapsfilled):
+    '''Check to see that the OUPUT trapsfilled
+    file was created.'''
+    x,y = fits_input['SCI'].data.shape[-2:]
+    print("Science data shape (x,y) = ({},{})".format(x,y))
+    assert traps_hdul['SCI'].data.shape == (3,y,x)
+
+    
+def test_persistence_output_pers_shape(fits_input,pers_hdul,trapsfilled):
+    '''Check that the optional output file
+    "_output_pers.fits" was created if
+    the save_persistence option in the persistence
+    step was set to True. (Assume this test will
+    only be called in instances when save_persistence
+    is True'''
+    opshape = pers_hdul['SCI'].data.shape
+    print("Output_pers data shape: {}".format(opshape))
+    assert opshape == fits_input['SCI'].data.shape
+
+
+def test_persistence_subtracted_signal(fits_input, out_hdul, pers_hdul, trapsfilled):
+    '''Check that the signal values contained in the 
+    output_pers file are indeed subtracted from the original
+    input file.'''
+    assert np.allclose(out_hdul[1].data,fits_input[1].data - pers_hdul[1].data)
+
+
+def test_persistence_dq_flagged_pix(out_hdul,pers_hdul,trapsfilled,flagthresh=40):
+    '''Pixels that have more persistence signal than flag_pers_cutoff
+    should be flagged in the DQ array of the output file. The default
+    value of flag_pers_cutoff is 40 DN'''
+    # Check only integration #1
+    pdata = pers_hdul['SCI'].data[0,:,:,:]
+    # Keep only the maximum persistence value
+    # for each pixel
+    if ((flagthresh is not None) and (flagthresh > 0)):
+        collapsed = np.max(pdata,axis=0)
+        flagged = collapsed > flagthresh
+        dq_data = out_hdul['PIXELDQ'].data
+        print(("{} pixels have persistence values above the threshold "
+               "of {}.".format(np.sum(flagged),flagthresh)))
+        assert np.all(dq_data[flagged] & dqflags.pixel['DO_NOT_USE'] > 0)
+    else:
+        print("Flagthresh is {}".format(flagthresh))
+        assert True == True
+
+        
+#def test_calculated_persistence(fits_input,pers_hdul,persat_hdul,trapsfilled):
+#    '''Using Regan's paper (JWST-STScI-005689), manually
+#    calculate the expected amount of persistence in the input
+#    file, and compare to the pipeline's calculations
+#
+#    Not sure how to do this without simply copying the
+#    code in the jwst cal pipeline step.
+#    '''
+
+    #data = fits_input['SCI'].data[0,:,:,:]
+    #f21 = data[1,:,:] = data[0,:,:]
+    #fw_frac = f21 / persat_hdul['SCI']
+
+    #trapc - total number of traps captured
+    #trape - num of traps that fit exponential decay (?)
+    #tau - time constant of capture
+    #trapi - num traps instantaneously captured
+    #S - rate of change in the depletion region in units of fraction of full
+    #    well per unit time
+    #T - integration time
+
+    #trapc = s*(T*(trape + trapi) + trape*tau*(exp(-T/tau) - 1))


### PR DESCRIPTION
Initial commit of test_assign_wcs.py. 

Basic tests are performed:
1. Run the assign_wcs pipeline step
2. Make sure the ASDF extension is added to the output file
3. Check that the RA, Dec at the reference location returned by the WCS model matches RA_REF, DEC_REF
4. Check that the RA, Dec difference between adjacent pixels matches the pixel scale as given by CDELT1, CDELT2
5. For grism data, check that RA, Dec, and wavelength differences when moving between pixels matches what you would expect given the dispersion direction of the data.
6. For imaging data only: 
For a given x,y pixel on the detector, translate to RA, Dec and back to x,y using the WCS model in the output file. Do the same using the WCS model in the distortion reference file. Make sure the round trip translations match.

These tests were all derived and tested using NIRCam data. For grism tests, I include the NIRISS grism names, which should allow testing of NIRISS data, as NIRISS and NIRCam grism modes are so similar.